### PR TITLE
use correct prefix to link native macos libraries

### DIFF
--- a/src/net_iot/net_iot_core/net_iot_core.csproj
+++ b/src/net_iot/net_iot_core/net_iot_core.csproj
@@ -49,7 +49,9 @@
     </ContentWithTargetPath>
     <ContentWithTargetPath Include="Library/darwin/arch/arm64/UsbEventWatcher.Mac.dylib" Condition=" '$(RuntimeIdentifier)' == 'osx-arm64' OR ( '$(RuntimeIdentifier)' == '' AND $([MSBuild]::IsOsPlatform('OSX')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64' )">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <TargetPath>UsbEventWatcher.Mac.dylib</TargetPath>
+      <!-- lib is required as a prefix to link the native library -->
+      <!-- https://github.com/dotnet/maui/issues/7829 -->
+      <TargetPath>libUsbEventWatcher.Mac.dylib</TargetPath>
     </ContentWithTargetPath>
     <ContentWithTargetPath Include="Library/linux/arch/x64/UsbEventWatcher.Linux.so" Condition=" '$(RuntimeIdentifier)' == 'linux-x64' OR ( '$(RuntimeIdentifier)' == '' AND $([MSBuild]::IsOsPlatform('Linux')) AND '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64' )">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
This looks like an active issue where lib is required as a prefix to link native libraries for .NET on MacOS. So far it only appears to be an issue on arm 64.

Error I was seeing:


System. DIlNotFoundException: Unable to load shared library
'UsbEventWatcher.Mac.dylib' or one of its dependencies. In order to help
System diagnose loading problems, consider setting the DYLD PRINT LIBRARIES
enviromon varano
dlopen(/Applications/byte-burner.app/Contents/Resources/net_iot_api/
System.
UsbEventWatcher. Mac.dylib, 0x0001): tried: 'Applications/byte burner.app/Contents Resources/net jot apin
UsbEventWatcher.Mac.dylib' (mach-o file, but is an incompatible architecture (have '×86_64', need 'arm64')), '/System/Volumes/Preboot/
System. Cryptexes/OS/Applications/byte-burner.app/Contents/Resources/
net_jot_api/UsbEventWatcher.Mac.dylib' (no such file), '/Applications/byte-
burner.and Contents Resources net lot apu
UsbEventWatcher.Mac.dvlib' (mach-o file. but is an incompatible
1-10 architecture (have 'x86_64', need 'arm64*)) dlopen(UsbEventWatcher.Mac.dylib, 0x0001): tried:
'UsbEventWatcher.Mac.dylib' (no such file), 'System/Volumes/Preboot/ Crvptexes/OSUsbEventWatcher.Mac.dvlib'(no such file), "usr/lib/
UsbEventWatcher.Mac.dyl

------------------------------------------------

Resources:

https://github.com/dotnet/maui/issues/7829